### PR TITLE
Fix OAuth session cleanup log condition

### DIFF
--- a/backend/golang/pkg/db/oauth.go
+++ b/backend/golang/pkg/db/oauth.go
@@ -402,7 +402,7 @@ func (s *Store) GetAndClearOAuthProviderAndVerifier(
 	} else {
 		// Log how many expired sessions were cleaned up
 		rowsAffected, err := deleteResult.RowsAffected()
-		if err != nil && rowsAffected > 0 {
+		if err == nil && rowsAffected > 0 {
 			logger.Debugf("Cleaned up %d expired OAuth sessions", rowsAffected)
 		}
 	}


### PR DESCRIPTION
## Summary
- log cleanup only when `RowsAffected` succeeds

## Testing
- `make -C backend/golang build` *(fails: go.mod requires go >= 1.24.2)*