### PR TITLE
Add image preview modal

### DIFF
--- a/app/src/renderer/src/components/chat/ImagePreview.tsx
+++ b/app/src/renderer/src/components/chat/ImagePreview.tsx
@@ -1,0 +1,29 @@
+import { useState } from 'react'
+import { Dialog, DialogTrigger, DialogContent } from '../ui/dialog'
+import { cn } from '@renderer/lib/utils'
+
+interface ImagePreviewProps {
+  src: string
+  alt?: string
+  thumbClassName?: string
+  className?: string
+}
+
+export default function ImagePreview({ src, alt, thumbClassName, className }: ImagePreviewProps) {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <img
+          src={src}
+          alt={alt}
+          className={cn('cursor-zoom-in', thumbClassName)}
+        />
+      </DialogTrigger>
+      <DialogContent className={cn('p-0 bg-transparent border-none max-w-fit', className)}>
+        <img src={src} alt={alt} className="max-h-[80vh] max-w-[80vw] object-contain rounded" />
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/app/src/renderer/src/components/chat/Message.tsx
+++ b/app/src/renderer/src/components/chat/Message.tsx
@@ -4,6 +4,7 @@ import { cn } from '@renderer/lib/utils'
 import { CheckCircle, ChevronRight, Lightbulb, LoaderIcon, Volume2, VolumeOff } from 'lucide-react'
 import { extractReasoningAndReply, formatToolName } from './config'
 import { Badge } from '../ui/badge'
+import ImagePreview from './ImagePreview'
 import Markdown from './Markdown'
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '../ui/collapsible'
 import { useTTS } from '@renderer/hooks/useTTS'
@@ -28,11 +29,11 @@ export function UserMessageBubble({ message }: { message: Message }) {
         {message.imageUrls.length > 0 && (
           <div className="flex gap-2 mt-2">
             {message.imageUrls.map((url, i) => (
-              <img
+              <ImagePreview
                 key={i}
                 src={url}
                 alt={`attachment-${i}`}
-                className="inline-block h-32 w-32 object-cover rounded"
+                thumbClassName="inline-block h-32 w-32 object-cover rounded"
               />
             ))}
           </div>
@@ -83,11 +84,11 @@ export function AssistantMessageBubble({ message }: { message: Message }) {
         {message.imageUrls.length > 0 && (
           <div className="flex flex-col gap-2 my-2">
             {message.imageUrls.map((url, i) => (
-              <img
+              <ImagePreview
                 key={i}
                 src={url}
                 alt={`attachment-${i}`}
-                className="inline-block h-40 w-40 object-cover rounded"
+                thumbClassName="inline-block h-40 w-40 object-cover rounded"
               />
             ))}
           </div>


### PR DESCRIPTION
## Summary
- allow clicking chat images to open larger preview
- create `ImagePreview` component for the dialog

## Testing
- `pnpm lint` *(fails: Cannot find package '@electron-toolkit/eslint-config-ts')*
- `pnpm typecheck` *(fails: Cannot find type definition file for 'electron-vite/node')*