### PR TITLE
Show Kokoro installation progress

### DIFF
--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -15,7 +15,7 @@ import { registerMediaPermissionHandlers, registerPermissionIpc } from './mediaP
 import { registerScreenpipeIpc, cleanupScreenpipe } from './screenpipe'
 import { registerAccessibilityIpc } from './accessibilityPermissions'
 import { windowManager } from './windows'
-import { KokoroBootstrap } from './pythonManager'
+import { KokoroBootstrap, DependencyProgress } from './pythonManager'
 
 const PATHNAME = 'input_data'
 const DEFAULT_OAUTH_SERVER_PORT = 8080
@@ -442,10 +442,11 @@ app.whenReady().then(async () => {
   const dbPath = join(dbDir, 'enchanted-twin.db')
   log.info(`Database path: ${dbPath}`)
 
-  const kokoroProgress = (progress: number, status?: string) => {
+  const kokoroProgress = (data: DependencyProgress) => {
     if (mainWindow) {
+      const { progress, status } = data
       log.info(`[Kokoro] Emitting launch-progress: ${progress}, Status: ${status}`)
-      mainWindow.webContents.send('launch-progress', { progress, status })
+      mainWindow.webContents.send('launch-progress', data)
     }
   }
 

--- a/app/src/main/pythonManager.ts
+++ b/app/src/main/pythonManager.ts
@@ -3,10 +3,18 @@ import path from 'node:path'
 import fs, { constants as fsc } from 'node:fs'
 import { pipeline } from 'node:stream/promises'
 import { tmpdir } from 'node:os'
+import http from 'node:http'
 import https from 'node:https'
 import { spawn, SpawnOptions } from 'node:child_process'
 import unzipper from 'unzipper'
 import log from 'electron-log/main'
+
+export interface DependencyProgress {
+  dependency: string
+  progress: number
+  status: string
+  error?: string
+}
 
 type RunOptions = SpawnOptions & { label: string }
 
@@ -34,13 +42,14 @@ export class KokoroBootstrap {
   }
 
   private kokoroProc: import('child_process').ChildProcess | null = null
-  private onProgress?: (progress: number, status?: string) => void
-  private latestProgress: { progress: number; status: string; error?: string } = {
+  private onProgress?: (data: DependencyProgress) => void
+  private latestProgress: DependencyProgress = {
+    dependency: 'Kokoro',
     progress: 0,
     status: 'Not started'
   }
 
-  constructor(onProgress?: (progress: number, status?: string) => void) {
+  constructor(onProgress?: (data: DependencyProgress) => void) {
     this.onProgress = onProgress
   }
 
@@ -206,39 +215,60 @@ export class KokoroBootstrap {
       { cwd: this.KOKORO_DIR, env, stdio: 'inherit' }
     )
     this.kokoroProc.on('exit', () => (this.kokoroProc = null))
+
+    const checkServer = () =>
+      new Promise<boolean>((resolve) => {
+        const req = http.get('http://localhost:45000/web', (res) => {
+          res.resume()
+          resolve(res.statusCode === 200)
+        })
+        req.on('error', () => resolve(false))
+      })
+
+    const start = Date.now()
+    const timeout = 10 * 60 * 1000
+    while (Date.now() - start < timeout) {
+      if (await checkServer()) {
+        this.onProgress?.({ dependency: 'Kokoro', progress: 100, status: 'Completed' })
+        this.latestProgress = { dependency: 'Kokoro', progress: 100, status: 'Completed' }
+        return
+      }
+      await new Promise((r) => setTimeout(r, 1000))
+    }
+
+    throw new Error('Timed out waiting for Kokoro server to start')
   }
 
   async setup() {
     try {
-      this.onProgress?.(10, 'Setting up dependency manager')
-      this.latestProgress = { progress: 10, status: 'Setting up dependency manager' }
+      this.onProgress?.({ dependency: 'Kokoro', progress: 10, status: 'Setting up dependency manager' })
+      this.latestProgress = { dependency: 'Kokoro', progress: 10, status: 'Setting up dependency manager' }
       await this.ensureUv()
-      this.onProgress?.(20, 'Installing Python')
-      this.latestProgress = { progress: 20, status: 'Installing Python' }
+      this.onProgress?.({ dependency: 'Kokoro', progress: 20, status: 'Installing Python' })
+      this.latestProgress = { dependency: 'Kokoro', progress: 20, status: 'Installing Python' }
       await this.ensurePython312()
-      this.onProgress?.(30, 'Downloading Kokoro')
-      this.latestProgress = { progress: 30, status: 'Downloading Kokoro' }
+      this.onProgress?.({ dependency: 'Kokoro', progress: 30, status: 'Downloading Kokoro' })
+      this.latestProgress = { dependency: 'Kokoro', progress: 30, status: 'Downloading Kokoro' }
       await this.ensureRepo()
-      this.onProgress?.(45, 'Creating virtual environment')
-      this.latestProgress = { progress: 45, status: 'Creating virtual environment' }
+      this.onProgress?.({ dependency: 'Kokoro', progress: 45, status: 'Creating virtual environment' })
+      this.latestProgress = { dependency: 'Kokoro', progress: 45, status: 'Creating virtual environment' }
       await this.ensureVenv()
-      this.onProgress?.(60, 'Installing dependencies')
-      this.latestProgress = { progress: 60, status: 'Installing dependencies' }
+      this.onProgress?.({ dependency: 'Kokoro', progress: 60, status: 'Installing dependencies' })
+      this.latestProgress = { dependency: 'Kokoro', progress: 60, status: 'Installing dependencies' }
       await this.ensureDeps()
-      this.onProgress?.(90, 'Starting speech model')
-      this.latestProgress = { progress: 90, status: 'Starting speech model' }
-      this.startTts()
-      this.onProgress?.(100, 'Completed')
-      this.latestProgress = { progress: 100, status: 'Completed' }
+      this.onProgress?.({ dependency: 'Kokoro', progress: 90, status: 'Starting speech model' })
+      this.latestProgress = { dependency: 'Kokoro', progress: 90, status: 'Starting speech model' }
+      await this.startTts()
     } catch (e) {
       const error = e instanceof Error ? e.message : 'Unknown error occurred'
       log.error('[KokoroBootstrap] failed', e)
       this.latestProgress = {
+        dependency: 'Kokoro',
         progress: this.latestProgress.progress,
         status: 'Failed',
         error
       }
-      this.onProgress?.(0, 'Failed')
+      this.onProgress?.({ dependency: 'Kokoro', progress: 0, status: 'Failed', error })
       throw e
     }
   }

--- a/app/src/preload/index.ts
+++ b/app/src/preload/index.ts
@@ -62,8 +62,13 @@ const api = {
     stop: () => ipcRenderer.invoke('screenpipe:stop')
   },
   launch: {
-    onProgress: (callback: (data: { status: string; progress: number }) => void) => {
-      const listener = (_: unknown, data: { status: string; progress: number }) => callback(data)
+    onProgress: (
+      callback: (data: { dependency: string; status: string; progress: number; error?: string }) => void
+    ) => {
+      const listener = (
+        _: unknown,
+        data: { dependency: string; status: string; progress: number; error?: string }
+      ) => callback(data)
       ipcRenderer.on('launch-progress', listener)
       return () => ipcRenderer.removeListener('launch-progress', listener)
     },
@@ -72,7 +77,7 @@ const api = {
   },
   onLaunch: (
     channel: 'launch-complete' | 'launch-progress',
-    callback: (data: { status: string; progress: number } | void) => void
+    callback: (data: { dependency: string; status: string; progress: number; error?: string } | void) => void
   ) => {
     ipcRenderer.on(channel, (_, data) => callback(data))
   }

--- a/app/src/renderer/src/components/InstallationStatus.tsx
+++ b/app/src/renderer/src/components/InstallationStatus.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 
 interface InstallationStatus {
+  dependency: string
   progress: number
   status: string
   error?: string
@@ -8,6 +9,7 @@ interface InstallationStatus {
 
 export default function InstallationStatus() {
   const [installationStatus, setInstallationStatus] = useState<InstallationStatus>({
+    dependency: 'Kokoro',
     progress: 0,
     status: 'Not started'
   })
@@ -30,7 +32,9 @@ export default function InstallationStatus() {
       <h3 className="text-xl font-semibold mb-4">Dependencies</h3>
       <div className="flex flex-col gap-2">
         <div className="flex justify-between text-sm">
-          <span>{installationStatus.status}</span>
+          <span>
+            {installationStatus.dependency}: {installationStatus.status}
+          </span>
           <span>{installationStatus.progress}%</span>
         </div>
         <div className="w-full h-2 bg-gray-200 rounded-full overflow-hidden">

--- a/app/src/renderer/src/env.d.ts
+++ b/app/src/renderer/src/env.d.ts
@@ -59,13 +59,15 @@ interface IApi {
     stop: () => Promise<boolean>
   }
   launch: {
-    onProgress: (callback: (data: { status: string; progress: number }) => void) => () => void
+    onProgress: (
+      callback: (data: { dependency: string; status: string; progress: number; error?: string }) => void
+    ) => () => void
     notifyReady: () => void
     complete: () => Promise<void>
   }
   onLaunch: (
     channel: 'launch-complete' | 'launch-progress',
-    callback: (data: { status: string; progress: number } | void) => void
+    callback: (data: { dependency: string; status: string; progress: number; error?: string } | void) => void
   ) => void
 }
 


### PR DESCRIPTION
## Summary
- pass dependency name in Kokoro bootstrap progress updates
- update IPC preload typings for dependency progress
- display dependency name in InstallationStatus UI
- wait for Kokoro server before completing progress

## Testing
- `pnpm lint` *(fails: Cannot find package '@electron-toolkit/eslint-config-ts')*
- `pnpm typecheck` *(fails: Cannot find type definition file for 'electron-vite/node')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*