### PR TITLE
Add voice page

### DIFF
--- a/app/src/renderer/src/components/voice/MovingBall.tsx
+++ b/app/src/renderer/src/components/voice/MovingBall.tsx
@@ -1,0 +1,13 @@
+import { motion } from 'framer-motion'
+
+export default function MovingBall() {
+  return (
+    <div className="flex items-center justify-center w-full h-full">
+      <motion.div
+        className="w-24 h-24 bg-green-500 rounded-full"
+        animate={{ y: [0, -20, 0] }}
+        transition={{ repeat: Infinity, duration: 1.5, ease: 'easeInOut' }}
+      />
+    </div>
+  )
+}

--- a/app/src/renderer/src/routeTree.gen.ts
+++ b/app/src/renderer/src/routeTree.gen.ts
@@ -17,6 +17,7 @@ import { Route as OnboardingImport } from './routes/onboarding'
 import { Route as AdminImport } from './routes/admin'
 import { Route as IndexImport } from './routes/index'
 import { Route as ChatChatIdImport } from './routes/chat/$chatId'
+import { Route as VoiceChatIdImport } from './routes/voice/$chatId'
 
 // Create/Update Routes
 
@@ -53,6 +54,12 @@ const IndexRoute = IndexImport.update({
 const ChatChatIdRoute = ChatChatIdImport.update({
   id: '/chat/$chatId',
   path: '/chat/$chatId',
+  getParentRoute: () => rootRoute,
+} as any)
+
+const VoiceChatIdRoute = VoiceChatIdImport.update({
+  id: '/voice/$chatId',
+  path: '/voice/$chatId',
   getParentRoute: () => rootRoute,
 } as any)
 
@@ -102,6 +109,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ChatChatIdImport
       parentRoute: typeof rootRoute
     }
+    '/voice/$chatId': {
+      id: '/voice/$chatId'
+      path: '/voice/$chatId'
+      fullPath: '/voice/$chatId'
+      preLoaderRoute: typeof VoiceChatIdImport
+      parentRoute: typeof rootRoute
+    }
   }
 }
 
@@ -114,6 +128,7 @@ export interface FileRoutesByFullPath {
   '/settings': typeof SettingsRoute
   '/tasks': typeof TasksRoute
   '/chat/$chatId': typeof ChatChatIdRoute
+  '/voice/$chatId': typeof VoiceChatIdRoute
 }
 
 export interface FileRoutesByTo {
@@ -123,6 +138,7 @@ export interface FileRoutesByTo {
   '/settings': typeof SettingsRoute
   '/tasks': typeof TasksRoute
   '/chat/$chatId': typeof ChatChatIdRoute
+  '/voice/$chatId': typeof VoiceChatIdRoute
 }
 
 export interface FileRoutesById {
@@ -133,6 +149,7 @@ export interface FileRoutesById {
   '/settings': typeof SettingsRoute
   '/tasks': typeof TasksRoute
   '/chat/$chatId': typeof ChatChatIdRoute
+  '/voice/$chatId': typeof VoiceChatIdRoute
 }
 
 export interface FileRouteTypes {
@@ -144,8 +161,16 @@ export interface FileRouteTypes {
     | '/settings'
     | '/tasks'
     | '/chat/$chatId'
+    | '/voice/$chatId'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/admin' | '/onboarding' | '/settings' | '/tasks' | '/chat/$chatId'
+  to:
+    | '/'
+    | '/admin'
+    | '/onboarding'
+    | '/settings'
+    | '/tasks'
+    | '/chat/$chatId'
+    | '/voice/$chatId'
   id:
     | '__root__'
     | '/'
@@ -154,6 +179,7 @@ export interface FileRouteTypes {
     | '/settings'
     | '/tasks'
     | '/chat/$chatId'
+    | '/voice/$chatId'
   fileRoutesById: FileRoutesById
 }
 
@@ -164,6 +190,7 @@ export interface RootRouteChildren {
   SettingsRoute: typeof SettingsRoute
   TasksRoute: typeof TasksRoute
   ChatChatIdRoute: typeof ChatChatIdRoute
+  VoiceChatIdRoute: typeof VoiceChatIdRoute
 }
 
 const rootRouteChildren: RootRouteChildren = {
@@ -173,6 +200,7 @@ const rootRouteChildren: RootRouteChildren = {
   SettingsRoute: SettingsRoute,
   TasksRoute: TasksRoute,
   ChatChatIdRoute: ChatChatIdRoute,
+  VoiceChatIdRoute: VoiceChatIdRoute,
 }
 
 export const routeTree = rootRoute
@@ -190,7 +218,8 @@ export const routeTree = rootRoute
         "/onboarding",
         "/settings",
         "/tasks",
-        "/chat/$chatId"
+        "/chat/$chatId",
+        "/voice/$chatId"
       ]
     },
     "/": {
@@ -210,6 +239,9 @@ export const routeTree = rootRoute
     },
     "/chat/$chatId": {
       "filePath": "chat/$chatId.tsx"
+    },
+    "/voice/$chatId": {
+      "filePath": "voice/$chatId.tsx"
     }
   }
 }

--- a/app/src/renderer/src/routes/voice/$chatId.tsx
+++ b/app/src/renderer/src/routes/voice/$chatId.tsx
@@ -1,0 +1,130 @@
+// routes/voice/$chatId.tsx
+import { createFileRoute } from '@tanstack/react-router'
+import { client } from '@renderer/graphql/lib'
+import { GetChatDocument, Chat, Message, Role } from '@renderer/graphql/generated/graphql'
+import MessageInput from '@renderer/components/chat/MessageInput'
+import { UserMessageBubble } from '@renderer/components/chat/Message'
+import MovingBall from '@renderer/components/voice/MovingBall'
+import { useSendMessage } from '@renderer/hooks/useChat'
+import { useMessageStreamSubscription } from '@renderer/hooks/useMessageStreamSubscription'
+import { useMessageSubscription } from '@renderer/hooks/useMessageSubscription'
+import { useTTS } from '@renderer/hooks/useTTS'
+import { useState } from 'react'
+
+interface VoiceSearchParams {
+  initialMessage?: string
+}
+
+export const Route = createFileRoute('/voice/$chatId')({
+  component: VoiceRouteComponent,
+  validateSearch: (search: Record<string, unknown>): VoiceSearchParams => {
+    return {
+      initialMessage: typeof search.initialMessage === 'string' ? search.initialMessage : undefined
+    }
+  },
+  loader: async ({ params }) => {
+    try {
+      const { data } = await client.query({
+        query: GetChatDocument,
+        variables: { id: params.chatId },
+        fetchPolicy: 'network-only'
+      })
+
+      return {
+        data: data.getChat,
+        loading: false,
+        error: null
+      }
+    } catch (error: unknown) {
+      return {
+        data: null,
+        loading: false,
+        error: error instanceof Error ? error.message : 'An unknown error occurred'
+      }
+    }
+  },
+  pendingComponent: () => {
+    return (
+      <div className="flex flex-col items-center justify-center h-full">
+        <div className="flex items-center justify-center gap-2 h-20">
+          {[...Array(3)].map((_, i) => (
+            <div
+              key={i}
+              className="h-3 w-3 bg-green-500 rounded-full animate-bounce"
+              style={{ animationDelay: `${i * 0.15}s` }}
+            />
+          ))}
+        </div>
+      </div>
+    )
+  },
+  pendingMs: 100,
+  pendingMinMs: 300
+})
+
+function VoiceRouteComponent() {
+  const { data, error } = Route.useLoaderData()
+  const { initialMessage } = Route.useSearch()
+  const { speak } = useTTS()
+
+  const [lastUserMessage, setLastUserMessage] = useState<Message | null>(() => {
+    if (!data) return null
+    if (initialMessage && data.messages.length === 0) {
+      const msg: Message = {
+        id: `temp-${Date.now()}`,
+        text: initialMessage,
+        imageUrls: [],
+        role: Role.User,
+        toolCalls: [],
+        toolResults: [],
+        createdAt: new Date().toISOString()
+      }
+      return msg
+    }
+    const msg = [...data.messages].reverse().find((m) => m.role === Role.User) || null
+    return msg
+  })
+
+  const [assistantBuffer, setAssistantBuffer] = useState<{ id: string; text: string }>({ id: '', text: '' })
+
+  if (!data) return <div className="p-4">Invalid chat ID.</div>
+  if (error) return <div className="p-4 text-red-500">Error loading chat.</div>
+
+  const { sendMessage } = useSendMessage(
+    data.id,
+    (msg) => {
+      setLastUserMessage(msg)
+      setAssistantBuffer({ id: '', text: '' })
+    },
+    () => {}
+  )
+
+  useMessageSubscription(data.id, (message) => {
+    if (message.role === Role.Assistant) {
+      speak(message.text || '')
+    }
+  })
+
+  useMessageStreamSubscription(data.id, (messageId, chunk, isComplete) => {
+    setAssistantBuffer((prev) => {
+      const newText = prev.id === messageId ? prev.text + (chunk ?? '') : (chunk ?? '')
+      if (isComplete) {
+        speak(newText)
+        return { id: '', text: '' }
+      }
+      return { id: messageId, text: newText }
+    })
+  })
+
+  return (
+    <div className="flex flex-col h-full w-full items-center">
+      <div className="flex-1 flex items-center justify-center w-full">
+        <MovingBall />
+      </div>
+      <div className="w-full max-w-4xl flex flex-col gap-4 px-4 pb-4">
+        {lastUserMessage && <UserMessageBubble message={lastUserMessage} />}
+        <MessageInput isWaitingTwinResponse={false} onSend={sendMessage} />
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add simple moving ball component
- create voice page with message input
- speak assistant replies using TTS
- update route tree
- add Voice mode button in sidebar that creates a new chat and navigates to voice page

## Testing
- `npm run typecheck` *(fails: Cannot find type definition file for 'electron-vite/node')*