### PR TITLE
Add tools list to MCP servers

### DIFF
--- a/backend/golang/graph/schema.graphqls
+++ b/backend/golang/graph/schema.graphqls
@@ -226,6 +226,7 @@ type MCPServerDefinition {
   type: MCPServerType!
   connected: Boolean!
   enabled: Boolean!
+  tools: [Tool!]!
 }
 
 type Tool {


### PR DESCRIPTION
## Notes
- `make gqlgen`, `make lint`, and `make test` failed because Go 1.24 toolchain cannot be downloaded in the environment.

## Summary
- expose per-server tool list in GraphQL schema
- populate `Tools` for each MCP server when listing servers