### PR TITLE
Fix: VoiceVisualiser initial animation in speaking mode

### DIFF
--- a/app/src/renderer/src/components/chat/voice/VoiceVisualizer.tsx
+++ b/app/src/renderer/src/components/chat/voice/VoiceVisualizer.tsx
@@ -141,7 +141,7 @@ function CubeParticles({
       mesh.current.rotation.z = prog * Math.PI * 2
       material.uniforms.uState.value = THREE.MathUtils.damp(
         material.uniforms.uState.value,
-        1,
+        2,
         5,
         delta
       )


### PR DESCRIPTION
The VoiceVisualiser cube was not animating correctly on the first message send when entering the 'isSpeaking' state (state 2). This was because the animation was incorrectly targeting state 1 ('Loading') instead of state 2 ('Speaking') during the initial rotation sequence.

This commit corrects the target state in the `VoiceVisualizer.tsx` component to ensure the proper animation plays on the first use of voice mode.