### PR TITLE
feat: Allow dismissing image modal by clicking on overlay

### DIFF
--- a/app/src/renderer/src/components/ui/dialog.tsx
+++ b/app/src/renderer/src/components/ui/dialog.tsx
@@ -4,8 +4,23 @@ import { XIcon } from 'lucide-react'
 import { cn } from '@renderer/lib/utils'
 // import { useManagedModalZIndex } from '@renderer/hooks/useManagedModalZIndex' // Removed
 
-function Dialog({ ...props }: React.ComponentProps<typeof DialogPrimitive.Root>) {
-  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+interface DialogContextProps {
+  open?: boolean
+  onOpenChange?: (open: boolean) => void
+}
+
+const DialogContext = React.createContext<DialogContextProps | undefined>(undefined)
+
+function Dialog({
+  open,
+  onOpenChange,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return (
+    <DialogContext.Provider value={{ open, onOpenChange }}>
+      <DialogPrimitive.Root data-slot="dialog" open={open} onOpenChange={onOpenChange} {...props} />
+    </DialogContext.Provider>
+  )
 }
 
 function DialogTrigger({ ...props }: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
@@ -26,8 +41,15 @@ function DialogOverlay(
     ...props
   }: React.ComponentProps<typeof DialogPrimitive.Overlay> /* & { dynamicZIndex?: number } */
 ) {
+  const context = React.useContext(DialogContext)
+  const handleClick = () => {
+    if (context?.open && context?.onOpenChange) {
+      context.onOpenChange(false)
+    }
+  }
   return (
     <DialogPrimitive.Overlay
+      onClick={handleClick}
       data-slot="dialog-overlay"
       className={cn(
         'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 bg-black/50 backdrop-blur-sm',


### PR DESCRIPTION
This commit modifies the Dialog component to allow you to dismiss the full-screen image modal by clicking on the overlay (the black space surrounding the image).

Previously, the modal could only be dismissed by clicking the 'X' button. This change enhances your experience by providing a more intuitive way to close the modal.

A React context (`DialogContext`) was introduced to share the `onOpenChange` function and `open` state between the `Dialog` and `DialogOverlay` components. The `DialogOverlay` now has an `onClick` handler that triggers `onOpenChange(false)` when the dialog is open.