### PR TITLE
Allow closing image preview by clicking backdrop

### DIFF
--- a/app/src/renderer/src/components/chat/ImagePreview.tsx
+++ b/app/src/renderer/src/components/chat/ImagePreview.tsx
@@ -19,6 +19,7 @@ export default function ImagePreview({ src, alt, thumbClassName, className }: Im
         <img src={src} alt={alt} className={cn('cursor-zoom-in', thumbClassName)} />
       </DialogTrigger>
       <DialogContent
+        onClick={() => setOpen(false)}
         className={cn('p-0 g-transparent border-none w-full max-w-none rounded-xl', className)}
       >
         <VisuallyHidden>
@@ -27,7 +28,7 @@ export default function ImagePreview({ src, alt, thumbClassName, className }: Im
         <VisuallyHidden>
           <DialogDescription>Preview of the selected image</DialogDescription>
         </VisuallyHidden>
-        <div className="flex items-center justify-center">
+        <div className="flex items-center justify-center" onClick={e => e.stopPropagation()}>
           <img src={src} alt={alt} className="object-contain rounded-xl" />
         </div>
       </DialogContent>


### PR DESCRIPTION
## Summary
- close the image preview dialog when clicking the background

## Testing
- `pnpm lint` *(fails: Cannot find package '@electron-toolkit/eslint-config-ts')*
- `make lint` *(fails: go toolchain download blocked by network)*
- `make test` *(fails: go toolchain download blocked by network)*