### PR TITLE
Allow closing image preview by clicking backdrop

### DIFF
--- a/app/src/renderer/src/components/chat/ImagePreview.tsx
+++ b/app/src/renderer/src/components/chat/ImagePreview.tsx
@@ -19,6 +19,7 @@ export default function ImagePreview({ src, alt, thumbClassName, className }: Im
         <img src={src} alt={alt} className={cn('cursor-zoom-in', thumbClassName)} />
       </DialogTrigger>
       <DialogContent
+        onClick={() => setOpen(false)}
         className={cn('p-0 g-transparent border-none w-full max-w-none rounded-xl', className)}
       >
         <VisuallyHidden>
@@ -27,7 +28,7 @@ export default function ImagePreview({ src, alt, thumbClassName, className }: Im
         <VisuallyHidden>
           <DialogDescription>Preview of the selected image</DialogDescription>
         </VisuallyHidden>
-        <div className="flex items-center justify-center">
+        <div className="flex items-center justify-center" onClick={e => e.stopPropagation()}>
           <img src={src} alt={alt} className="object-contain rounded-xl" />
         </div>
       </DialogContent>

--- a/app/src/renderer/src/components/chat/voice/toolCallCenter/ImageGallery.tsx
+++ b/app/src/renderer/src/components/chat/voice/toolCallCenter/ImageGallery.tsx
@@ -42,6 +42,7 @@ export default function ImageGallery({ images, initialIndex = 0, onClose }: Imag
       <DialogContent
         className="min-w-full w-full h-full p-0 border-none bg-background"
         aria-describedby={undefined}
+        onClick={onClose}
       >
         <button
           onClick={onClose}
@@ -50,7 +51,10 @@ export default function ImageGallery({ images, initialIndex = 0, onClose }: Imag
           <X className="h-8 w-8" />
         </button>
 
-        <div className="relative w-full h-full flex items-center justify-center">
+        <div
+          className="relative w-full h-full flex items-center justify-center"
+          onClick={(e) => e.stopPropagation()}
+        >
           {images.length > 1 && (
             <button
               onClick={previousImage}


### PR DESCRIPTION
## Summary
- close the image gallery dialog when clicking the background

## Testing
- `pnpm lint` *(fails: Cannot find package '@electron-toolkit/eslint-config-ts')*
- `make lint` *(fails: No rule to make target 'lint')*
- `make test` *(fails: No rule to make target 'test')*