### PR TITLE
Fix Memory Error

### DIFF
--- a/backend/golang/pkg/agent/memory/evolvingmemory/pure.go
+++ b/backend/golang/pkg/agent/memory/evolvingmemory/pure.go
@@ -113,12 +113,16 @@ func CreateMemoryObject(fact ExtractedFact, decision MemoryDecision) *models.Obj
 		metadata["speakerID"] = fact.SpeakerID
 	}
 
+	// Get tags from the source document
+	tags := fact.Source.Original.Tags()
+
 	return &models.Object{
 		Class: ClassName,
 		Properties: map[string]interface{}{
 			"content":      fact.Content,
 			"metadataJson": marshalMetadata(metadata),
 			"timestamp":    fact.Source.Timestamp.Format(time.RFC3339),
+			"tags":         tags,
 		},
 	}
 }

--- a/backend/golang/pkg/agent/memory/evolvingmemory/storage/storage.go
+++ b/backend/golang/pkg/agent/memory/evolvingmemory/storage/storage.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/charmbracelet/log"
@@ -235,6 +236,7 @@ func (s *WeaviateStorage) EnsureSchemaExists(ctx context.Context) error {
 				contentProperty:   "text",
 				timestampProperty: "date",
 				metadataProperty:  "text",
+				tagsProperty:      "text[]",
 			}
 
 			existingProps := make(map[string]string)
@@ -279,6 +281,11 @@ func (s *WeaviateStorage) EnsureSchemaExists(ctx context.Context) error {
 				Name:        metadataProperty,
 				DataType:    []string{"text"},
 				Description: "JSON-encoded metadata for the memory",
+			},
+			{
+				Name:        tagsProperty,
+				DataType:    []string{"text[]"},
+				Description: "Tags associated with the memory",
 			},
 		},
 		Vectorizer: "none", // We provide our own vectors
@@ -332,7 +339,11 @@ func (s *WeaviateStorage) Query(ctx context.Context, queryText string) (memory.Q
 	}
 
 	if len(resp.Errors) > 0 {
-		return memory.QueryResult{}, fmt.Errorf("GraphQL query errors: %v", resp.Errors)
+		var errorMsgs []string
+		for _, err := range resp.Errors {
+			errorMsgs = append(errorMsgs, err.Message)
+		}
+		return memory.QueryResult{}, fmt.Errorf("GraphQL query errors: %s", strings.Join(errorMsgs, "; "))
 	}
 
 	finalResults := []memory.TextDocument{}
@@ -458,7 +469,11 @@ func (s *WeaviateStorage) QueryWithDistance(ctx context.Context, queryText strin
 	}
 
 	if len(resp.Errors) > 0 {
-		return memory.QueryWithDistanceResult{}, fmt.Errorf("GraphQL query errors: %v", resp.Errors)
+		var errorMsgs []string
+		for _, err := range resp.Errors {
+			errorMsgs = append(errorMsgs, err.Message)
+		}
+		return memory.QueryWithDistanceResult{}, fmt.Errorf("GraphQL query errors: %s", strings.Join(errorMsgs, "; "))
 	}
 
 	finalResults := []memory.DocumentWithDistance{}


### PR DESCRIPTION

Here's a great PR summary for your changes:

## Fix Memory Test Integration: Add Tags Support and Improve Error Handling

### 🐛 Problem
The `make test-memory` command was failing with GraphQL errors that showed memory addresses instead of meaningful error messages, and the evolvingmemory package had a schema mismatch where tags were expected but not defined.

### 🔧 Changes Made

#### 1. **Improved GraphQL Error Handling**
- **File**: `storage/storage.go`
- **Fix**: Extract actual error messages from GraphQL responses instead of printing memory addresses
- **Before**: `GraphQL query errors: [0x14005c48080]`
- **After**: `GraphQL query errors: Cannot query field "tags" on type "TextDocument"`

#### 2. **Added Tags Support to Weaviate Schema**
- **File**: `storage/storage.go`
- **Added**: `tags` property (`text[]`) to the TextDocument schema
- **Updated**: Schema validation to include tags property check
- **Impact**: Resolves schema mismatch between code expectations and Weaviate schema

#### 3. **Updated Memory Object Creation**
- **File**: `pure.go`
- **Added**: Tags from source documents are now properly included when creating memory objects
- **Fix**: `CreateMemoryObject()` now includes `"tags": tags` in the properties

### ✅ Results
- ✅ `make test-memory` now runs successfully 
- ✅ Memory integration test completes without errors
- ✅ ChatGPT conversation documents processed correctly with tags
- ✅ Meaningful error messages for debugging

### 🧪 Testing
- Tested with fresh Weaviate schema creation
- Verified end-to-end memory processing pipeline
- Integration test completes successfully with proper fact extraction and storage

### 📝 Notes
This fix ensures the evolvingmemory package properly handles tags throughout the entire pipeline, from document ingestion to Weaviate storage, while providing clear error messages for debugging.
