### PR TITLE
fix: handle user profile retrieval error gracefully

### DIFF
--- a/backend/golang/pkg/twinchat/twinchat.go
+++ b/backend/golang/pkg/twinchat/twinchat.go
@@ -165,6 +165,7 @@ func (s *Service) SendMessage(
 
 	userMemoryProfile, err := s.identityService.GetUserProfile(ctx)
 	if err != nil {
+		s.logger.Error("failed to get user memory profile", "error", err)
 		userMemoryProfile = ""
 	}
 


### PR DESCRIPTION
Set userMemoryProfile to an empty string if retrieving the user profile fails, preventing potential nil dereference issues.