### PR TITLE
added env vars from build to prod-runs

### DIFF
--- a/app/electron.vite.config.ts
+++ b/app/electron.vite.config.ts
@@ -18,7 +18,10 @@ export default defineConfig(({ mode }) => {
   return {
     main: {
       plugins: [externalizeDepsPlugin()],
-      define: inlineEnvVars('', env)
+      define: {
+        ...inlineEnvVars('', env),
+        __APP_ENV__: JSON.stringify(env)
+      }
     },
     preload: {
       plugins: [externalizeDepsPlugin()]
@@ -30,6 +33,9 @@ export default defineConfig(({ mode }) => {
         alias: {
           '@renderer': resolve('src/renderer/src')
         }
+      },
+      define: {
+        __APP_ENV__: JSON.stringify(env)
       },
       plugins: [
         TanStackRouterVite({ target: 'react', autoCodeSplitting: true }),

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -32,6 +32,17 @@ log.transports.file.level = 'info' // Log info level and above to file
 log.info(`Log file will be written to: ${log.transports.file.getFile().path}`)
 log.info(`Running in ${IS_PRODUCTION ? 'production' : 'development'} mode`)
 
+// Inject build-time environment variables into runtime process.env
+// __APP_ENV__ is replaced with a JSON object by electron-vite at build time
+// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+declare const __APP_ENV__: Record<string, string>
+
+for (const [key, val] of Object.entries(typeof __APP_ENV__ === 'object' ? __APP_ENV__ : {})) {
+  if (!(key in process.env)) {
+    process.env[key] = val
+  }
+}
+
 app.whenReady().then(async () => {
   log.info(`App version: ${app.getVersion()}`)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Environment variables are now accessible in both the main and renderer processes, improving consistency across the application.

- **Chores**
  - Updated configuration to inject build-time environment variables into the runtime environment without overwriting existing values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->