### PR TITLE
fix: initialize Enchanted MCP server on connect ETERNIS-1112

### DIFF
--- a/backend/golang/pkg/mcpserver/mcpserver.go
+++ b/backend/golang/pkg/mcpserver/mcpserver.go
@@ -143,6 +143,19 @@ func (s *service) ConnectMCPServer(
 			if err != nil {
 				return nil, fmt.Errorf("failed to start MCP client: %w", err)
 			}
+
+			initRequest := mcp.InitializeRequest{}
+			initRequest.Params.ProtocolVersion = mcp.LATEST_PROTOCOL_VERSION
+			initRequest.Params.ClientInfo = mcp.Implementation{
+				Name:    "enchanted-twin-mcp-client",
+				Version: "1.0.0",
+			}
+
+			_, err = mcpClient.Initialize(ctx, initRequest)
+			if err != nil {
+				return nil, fmt.Errorf("failed to initialize MCP client: %w", err)
+			}
+
 			client = mcpClient
 		default:
 			return nil, fmt.Errorf("unsupported server type")


### PR DESCRIPTION
Initialize the MCP client while connecting with it.

Earlier this was only done during load, which did not work because the server implementation did not match the client implementation and it failed to connect.

This should be merged with https://github.com/EternisAI/Enchanted-Mcp/pull/2 so that the MCP server implementation would work with this client implementation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added explicit initialization for connections to Enchanted MCP servers, ensuring the client is properly set up with the latest protocol version and client information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->