### PR TITLE
chore: use production Freysa Video MCP

### DIFF
--- a/backend/golang/pkg/mcpserver/default_servers.go
+++ b/backend/golang/pkg/mcpserver/default_servers.go
@@ -99,7 +99,7 @@ func getDefaultMCPServers() map[model.MCPServerType]*model.MCPServer {
 			ID:      "freysa-video",
 			Name:    "Freysa Video",
 			Command: "url",
-			Args:    []string{"https://freysa-video-mcp-dev.up.railway.app/mcp"},
+			Args:    []string{"https://freysa-video-mcp-production.up.railway.app/mcp"},
 			Enabled: enabled,
 			Type:    model.MCPServerTypeFreysa,
 		},


### PR DESCRIPTION
Use the production deploy of Freysa Video MCP.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the MCP server configuration to use the production endpoint instead of the development endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->