### PR TITLE
feat: auto-connect to Enchanted MCP using Firebase auth tokens

### DIFF
--- a/app/src/renderer/src/components/oauth/MCPPanel.tsx
+++ b/app/src/renderer/src/components/oauth/MCPPanel.tsx
@@ -6,7 +6,7 @@ import {
 } from '@renderer/graphql/generated/graphql'
 import MCPServerItem from './MCPServerItem'
 import { toast } from 'sonner'
-import { useEffect, useMemo } from 'react'
+import { useMemo } from 'react'
 import { Skeleton } from '@renderer/components/ui/skeleton'
 import { motion } from 'framer-motion'
 import { PROVIDER_CONFIG } from '@renderer/constants/mcpProviders'
@@ -40,24 +40,6 @@ export default function MCPPanel() {
 
   const allMcpServers = useMemo(() => data?.getMCPServers || [], [data])
 
-  // Enchanted server is only allowed if Google is connected
-  const hasGoogleConnected = useMemo(
-    () => allMcpServers.some((server) => server.type === McpServerType.Google && server.connected),
-    [allMcpServers]
-  )
-
-  useEffect(() => {
-    if (allMcpServers.length === 0) return
-
-    const enchantedServer = allMcpServers.find(
-      (server) => server.type === McpServerType.Enchanted && server.connected
-    )
-
-    if (enchantedServer && !hasGoogleConnected) {
-      deleteMcpServer({ variables: { id: enchantedServer.id } })
-    }
-  }, [allMcpServers, hasGoogleConnected, deleteMcpServer])
-
   const serversByType = useMemo(() => {
     const grouped = allMcpServers.reduce(
       (acc, server) => {
@@ -70,16 +52,8 @@ export default function MCPPanel() {
       {} as Partial<Record<McpServerType, typeof allMcpServers>>
     )
 
-    // Filter out Enchanted servers when Google isn't connected
-    if (!hasGoogleConnected && McpServerType.Enchanted in grouped) {
-      const enchantedGroup = grouped[McpServerType.Enchanted]
-      if (enchantedGroup !== undefined) {
-        delete grouped[McpServerType.Enchanted]
-      }
-    }
-
     return grouped
-  }, [allMcpServers, hasGoogleConnected])
+  }, [allMcpServers])
 
   const serverTypes = useMemo(() => {
     return Object.keys(serversByType)

--- a/backend/golang/pkg/mcpserver/mcpserver.go
+++ b/backend/golang/pkg/mcpserver/mcpserver.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/EternisAI/enchanted-twin/graph/model"
 	"github.com/EternisAI/enchanted-twin/pkg/agent/tools"
-	"github.com/EternisAI/enchanted-twin/pkg/auth"
 	"github.com/EternisAI/enchanted-twin/pkg/config"
 	"github.com/EternisAI/enchanted-twin/pkg/db"
 	"github.com/EternisAI/enchanted-twin/pkg/mcpserver/internal/google"
@@ -130,16 +129,11 @@ func (s *service) ConnectMCPServer(
 			if s.config.EnchantedMcpURL == "" {
 				return nil, fmt.Errorf("ENCHANTED_MCP_URL is not configured")
 			}
-			// In case there is google oauth token, refresh it
-			_, err := auth.RefreshOAuthToken(ctx, log.Default(), s.store, "google")
-			if err != nil {
-				return nil, fmt.Errorf("failed to refresh oauth tokens: %w", err)
-			}
 
-			// Add OAuth support for the new client
-			oauth, err := s.store.GetOAuthTokens(ctx, "google")
+			// Get Firebase tokens from login
+			oauth, err := s.store.GetOAuthTokens(ctx, "firebase")
 			if err != nil {
-				return nil, fmt.Errorf("failed to get oauth tokens: %w", err)
+				return nil, fmt.Errorf("failed to get firebase tokens: %w", err)
 			}
 
 			// Create client with OAuth authorization headers
@@ -467,16 +461,11 @@ func (s *service) LoadMCP(ctx context.Context) error {
 					log.Error("Config is nil, cannot connect to Enchanted MCP server", "server", server.Name)
 					continue
 				}
-				// In case there is google oauth token, refresh it
-				_, err := auth.RefreshOAuthToken(ctx, log.Default(), s.store, "google")
-				if err != nil {
-					log.Error("Error refreshing oauth tokens", "error", err)
-				}
 
-				// Add OAuth support
-				oauth, err := s.store.GetOAuthTokens(ctx, "google")
+				// Get Firebase tokens from login
+				oauth, err := s.store.GetOAuthTokens(ctx, "firebase")
 				if err != nil {
-					log.Error("Error getting oauth tokens for MCP server", "server", server.Name, "error", err)
+					log.Error("Error getting firebase tokens for MCP server", "server", server.Name, "error", err)
 					continue
 				}
 


### PR DESCRIPTION
Enchanted MCP now uses Firebase authentication tokens. Related PR in proxy server: https://github.com/EternisAI/enchanted-proxy/pull/11

Automatically connects to the Enchanted MCP server after login if it is not already connected.

Partially fixes [ETERNIS-1208](https://linear.app/eternis/issue/ETERNIS-1208/use-same-credentials-for-enchanted-app-freysa-mcp-enchanted-mcp)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically connects an Enchanted MCP server after login if none is connected.

* **Bug Fixes**
  * Removed the requirement for a connected Google MCP server before connecting an Enchanted MCP server.

* **Refactor**
  * Updated authentication logic to use Firebase tokens instead of Google OAuth tokens for MCP server connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->