### PR TITLE
fix: remove trailing slash from proxy server URL

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,7 +100,7 @@ jobs:
           TTS_URL: https://audio-processing.model.tinfoil.sh/v1/
           STT_MODEL: whisper-large-v3-turbo
           STT_URL: https://audio-processing.model.tinfoil.sh/v1/
-          PROXY_TEE_URL: https://enchanted-proxy-dev.up.railway.app/
+          PROXY_TEE_URL: https://enchanted-proxy-dev.up.railway.app
           VITE_FIREBASE_API_KEY: AIzaSyBMQG7Kw8p1Ymm1j_A-x2Jxc-x4BakXz3k
           VITE_FIREBASE_AUTH_DOMAIN: freysa-prod.firebaseapp.com
           VITE_FIREBASE_PROJECT_ID: freysa-prod


### PR DESCRIPTION
Fix trailing slash in proxy server URL which was causing 404 errors 🤦🏽‍♂️ 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release workflow configuration for the macOS app build to adjust the format of an environment variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->