### PR TITLE
fix: prevent context cancellation from losing assistant messages

### DIFF
--- a/backend/golang/graph/schema.resolvers.go
+++ b/backend/golang/graph/schema.resolvers.go
@@ -1099,8 +1099,8 @@ func (r *subscriptionResolver) ProcessMessageHistoryStream(ctx context.Context, 
 
 	r.Logger.Info("Processing message history with streaming", "data", string(historyJson))
 
-	// Use the streaming service method
-	streamChan, err := r.TwinChatService.ProcessMessageHistoryStream(ctx, chatID, messages, isOnboarding)
+	// Use the streaming service method with context isolation to prevent client disconnections from canceling message processing
+	streamChan, err := r.TwinChatService.ProcessMessageHistoryStream(context.WithoutCancel(ctx), chatID, messages, isOnboarding)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Use context.WithoutCancel in ProcessMessageHistoryStream GraphQL resolver to prevent client disconnections from cancelling message processing and causing assistant messages to be lost from the database.

This mirrors the same pattern used in SendMessage resolver and ensures messages are always persisted even if clients disconnect during streaming.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of message history streaming to prevent interruptions caused by client disconnections or cancellations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->