### PR TITLE
fix: incorrect MCP server name

### DIFF
--- a/app/src/renderer/src/contexts/AuthContext.tsx
+++ b/app/src/renderer/src/contexts/AuthContext.tsx
@@ -184,7 +184,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           await connectMcpServer({
             variables: {
               input: {
-                name: 'Starter',
+                name: 'Search & Image',
                 type: McpServerType.Enchanted,
                 command: 'npx',
                 args: [],


### PR DESCRIPTION
Incorrect MCP server name "Starter." It is changed to "Search & Image."

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the server selection for automatic connection after login to use "Search & Image" instead of "Starter" for the Enchanted MCP server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->