### PR TITLE
fix: add use_local parameter to necojackarc auto-request-review

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -142,3 +142,4 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           config: .github/auto_request_review.yml
+          use_local: true


### PR DESCRIPTION
## Summary
- Add `use_local: true` parameter to necojackarc/auto-request-review action
- This should allow the action to use the dynamically generated config file
- Fixes "Not Found" error when action tries to fetch config from repository

## Changes
- Added `use_local: true` to action parameters
- Config file is generated dynamically during workflow execution
- No need to commit static config files to repository

## Test Plan
- [ ] Verify workflow runs without "Not Found" errors
- [ ] Test reviewer assignment on different file changes
- [ ] Confirm ready_for_review trigger works properly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated reviewer assignment process for pull requests to use a new, centralized configuration, improving consistency and simplifying reviewer selection.
  * Reviewer assignment now ignores draft PRs and markdown files.
  * Enhanced the reviewer assignment workflow with improved configuration options for better local environment handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->