### PR TITLE
feat: add modify_email_labels tool

### DIFF
--- a/backend/golang/pkg/dataprocessing/workflows/x_sync.go
+++ b/backend/golang/pkg/dataprocessing/workflows/x_sync.go
@@ -140,7 +140,7 @@ func (w *DataProcessingWorkflows) XFetchActivity(
 		w.Logger.Debug("Refreshing expired Twitter token in X fetch activity")
 		_, err = auth.RefreshOAuthToken(ctx, w.Logger, w.Store, "twitter")
 		if err != nil {
-			return XFetchActivityResponse{}, fmt.Errorf("failed to refresh OAuth tokens: %w", err)
+			return XFetchActivityResponse{}, fmt.Errorf("twitter token refresh failed. Please reconnect Twitter to resume data sync: %w", err)
 		}
 		tokens, err = w.Store.GetOAuthTokensByUsername(ctx, "twitter", input.Username)
 		if err != nil {

--- a/backend/golang/pkg/mcpserver/internal/google/google.go
+++ b/backend/golang/pkg/mcpserver/internal/google/google.go
@@ -139,6 +139,17 @@ func (c *GoogleClient) CallTool(
 			return nil, err
 		}
 		content = result
+	case MODIFY_EMAIL_LABELS_TOOL_NAME:
+		var argumentsTyped ModifyEmailLabelsArguments
+		err := request.BindArguments(&argumentsTyped)
+		if err != nil {
+			return nil, err
+		}
+		result, err := processModifyEmailLabels(ctx, c.Store, argumentsTyped)
+		if err != nil {
+			return nil, err
+		}
+		content = result
 	case SEARCH_FILES_TOOL_NAME:
 		var argumentsTyped SearchFilesArguments
 		err := request.BindArguments(&argumentsTyped)

--- a/backend/golang/pkg/mcpserver/internal/twitter/twitter.go
+++ b/backend/golang/pkg/mcpserver/internal/twitter/twitter.go
@@ -86,7 +86,7 @@ func (c *TwitterClient) CallTool(
 		logger.Debug("Refreshing token for twitter")
 		_, err = auth.RefreshOAuthToken(ctx, logger, c.Store, "twitter")
 		if err != nil {
-			return nil, err
+			return mcp_golang.NewToolResultError("Twitter authentication expired. Please reconnect your Twitter account in settings to continue."), err
 		}
 		oauthTokens, err = c.Store.GetOAuthTokens(ctx, "twitter")
 		if err != nil {


### PR DESCRIPTION
This tool allows moving emails into different labels. For example, marking an email as read/unread or important or spam, etc.

Fixes [ETERNIS-1356](https://linear.app/eternis/issue/ETERNIS-1356/add-modify-labels-tool-to-gmail-mcp)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to modify Gmail email labels, allowing users to add or remove labels from individual emails.

* **Bug Fixes**
  * Improved error messages for Twitter authentication issues, providing clearer instructions when a token refresh fails.

* **Style**
  * Enhanced error messages related to Twitter and OAuth token refresh failures for better user understanding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->