### PR TITLE
ci: fix lint, move mcp-go away from feature branch

### DIFF
--- a/.github/workflows/golang-ci.yml
+++ b/.github/workflows/golang-ci.yml
@@ -6,6 +6,10 @@ on:
   push:
     branches: [main, master]
 
+permissions:
+  contents: read
+  pull-requests: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -17,8 +21,6 @@ jobs:
       backend: ${{ steps.changes.outputs.backend }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Determine if backend/golang changed
         id: changes
@@ -43,13 +45,15 @@ jobs:
         with:
           go-version-file: backend/golang/go.mod
           cache-dependency-path: backend/golang/go.sum
+          cache: true
 
       - name: Lint only the diff
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v8
         with:
           version: v2.1
           working-directory: backend/golang
-          args: --timeout=10m --new-from-rev=origin/${{ github.event.pull_request.base.ref }}
+          args: --timeout=10m
+          only-new-issues: true
 
       - name: Build
         run: make build

--- a/backend/golang/go.mod
+++ b/backend/golang/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/joho/godotenv v1.5.1
 	github.com/lib/pq v1.10.9
 	github.com/lnquy/cron v1.1.1
-	github.com/mark3labs/mcp-go v0.33.0
+	github.com/mark3labs/mcp-go v0.36.0
 	github.com/mattn/go-sqlite3 v2.0.3+incompatible
 	github.com/mnako/letters v0.2.5
 	github.com/nats-io/nats-server/v2 v2.11.3
@@ -400,4 +400,4 @@ replace google.golang.org/grpc => google.golang.org/grpc v1.71.1
 
 replace github.com/openai/openai-go => github.com/EternisAI/openai-go v0.0.0-20250606184246-5a5e4fffe44c
 
-replace github.com/mark3labs/mcp-go => github.com/pottekkat/mcp-go v0.26.1-0.20250717054748-800e5297e1c6
+// replace github.com/mark3labs/mcp-go => github.com/pottekkat/mcp-go v0.26.1-0.20250717054748-800e5297e1c6

--- a/backend/golang/go.sum
+++ b/backend/golang/go.sum
@@ -1509,6 +1509,8 @@ github.com/magiconair/properties v1.8.10/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mailru/easyjson v0.9.0 h1:PrnmzHw7262yW8sTBwxi1PdJA3Iw/EKBa8psRf7d9a4=
 github.com/mailru/easyjson v0.9.0/go.mod h1:1+xMtQp2MRNVL/V1bOzuP3aP8VNwRW55fQUto+XFtTU=
+github.com/mark3labs/mcp-go v0.36.0 h1:rIZaijrRYPeSbJG8/qNDe0hWlGrCJ7FWHNMz2SQpTis=
+github.com/mark3labs/mcp-go v0.36.0/go.mod h1:T7tUa2jO6MavG+3P25Oy/jR7iCeJPHImCZHRymCn39g=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
@@ -1682,8 +1684,6 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
-github.com/pottekkat/mcp-go v0.26.1-0.20250717054748-800e5297e1c6 h1:P4Hv9dNAVVKJzG5Xsb2L23LcgbMvtbKPcT2C588mk1I=
-github.com/pottekkat/mcp-go v0.26.1-0.20250717054748-800e5297e1c6/go.mod h1:rXqOudj/djTORU/ThxYx8fqEVj/5pvTuuebQ2RC7uk4=
 github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 h1:o4JXh1EVt9k/+g42oCprj/FisM4qX9L3sZB3upGN2ZU=
 github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
 github.com/prashantv/protectmem v0.0.0-20171002184600-e20412882b3a h1:AA9vgIBDjMHPC2McaGPojgV2dcI78ZC0TLNhYCXEKH8=


### PR DESCRIPTION
Fixes linter.

Moves away from my feature branch to the latest release for mcp-go.